### PR TITLE
Set body color to dark gray to better hide the loading.

### DIFF
--- a/PortalTeme/ClientApp/package.json
+++ b/PortalTeme/ClientApp/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start:prod": "ng serve --prod",
     "build": "ng build",
     "build:ssr": "npm run build -- --app=ssr --output-hashing=media",
     "test": "ng test",

--- a/PortalTeme/Views/Home/AngularIndex.cshtml
+++ b/PortalTeme/Views/Home/AngularIndex.cshtml
@@ -1,4 +1,8 @@
 ﻿
+@{ 
+    ViewData["LoadingText"] = "";
+}
+
 <partial name="_BaseAngularIndex" />
 @section Styles {
     <link rel="stylesheet" href="styles.css">

--- a/PortalTeme/Views/Home/DevAngularIndex.cshtml
+++ b/PortalTeme/Views/Home/DevAngularIndex.cshtml
@@ -1,4 +1,8 @@
 ﻿
+@{ 
+    ViewData["LoadingText"] = "Loading...";
+}
+
 <partial name="_BaseAngularIndex" />
 @section Scripts {
     <script type="text/javascript" src="runtime.js"></script>

--- a/PortalTeme/Views/Shared/_BaseAngularIndex.cshtml
+++ b/PortalTeme/Views/Shared/_BaseAngularIndex.cshtml
@@ -4,7 +4,9 @@
     ViewData["Title"] = "Portal Teme";
 }
 
-<app-root>Loading...</app-root>
+<app-root>
+    <span style="color: white;">@ViewData["LoadingText"]</span>
+</app-root>
 
 @Html.AntiForgeryToken()
 

--- a/PortalTeme/Views/Shared/_Layout.cshtml
+++ b/PortalTeme/Views/Shared/_Layout.cshtml
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     @RenderSection("Styles", false)
 </head>
-<body>
+<body style="background-color: #303030;">
     @RenderBody()
     @RenderSection("Scripts", true)
 </body>


### PR DESCRIPTION
+ Remove the loading text in production builds.